### PR TITLE
Augment info in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
 	"version": "1.0.1",
 	"description": "A lightweight library for working with the Nested Set Model",
 	"author": "Ferdi Schmidt",
+	"main": "nested-set-model.js",
 	"repository": {
 		"url": "https://github.com/uitgewis/nestedjs"
 	},
+	"license": "BSD-2-Clause",
 	"keywords": [
 		"nested set",
 		"nested set model"


### PR DESCRIPTION
This PR does two things:
#### Add an entrypoint

Right now you need to require the module like:

``` js
const NestedSetModel = require('nestedjs/nested-set-model');
```

Since this is the only export it isn't too convenient to look up the name of the file, so we can add [a main key](https://docs.npmjs.com/files/package.json#main) to the `package.json` so we can use it like:

``` js
const NestedSetModel = require('nestedjs');
```
#### Add license

`package.json` should also contain license information. Since this is in the repo, we can simply add it to the package information.

Thanks,
